### PR TITLE
HttpResponse.redirect calls HttpResponse.close

### DIFF
--- a/packages/spry/lib/src/_internal/response_impl.dart
+++ b/packages/spry/lib/src/_internal/response_impl.dart
@@ -38,6 +38,7 @@ class ResponseImpl extends Response {
   Future<void> redirect(Uri location,
       {int status = HttpStatus.movedTemporarily}) async {
     await response.redirect(location, status: status);
+    context.set(responseIsClosed, true);
   }
 
   @override


### PR DESCRIPTION
in http_impl.dart there is this code 
return _httpClient
        ._openUrlFromRequest(method, url, _httpRequest, isRedirect: true)
        .then((request) {
      request._responseRedirects
        ..addAll(redirects)
        ..add(_RedirectInfo(statusCode, method!, url!));
      return request.close();
    });
since redirect closes the request, we should mark as closed, otherwise app will crash